### PR TITLE
fix: 「あらすじを見る」ボタンが個別のあらすじに対応するよう修正

### DIFF
--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -18,11 +18,11 @@
         <%= movie.genres[1]['name'] %>
         <%= movie.genres[2]['name'] %>
       </div>
-      <button type="button" data-bs-toggle="collapse" data-bs-target="#movie_detail" aria-expanded="false" aria-controls="movie_detail" class="movie_detail text-white">
+      <button type="button" data-bs-toggle="collapse" data-bs-target="#js-movie_detail_<%= movie.id %>" aria-expanded="false" aria-controls="#js-movie_detail_<%= movie.id %>" class="js-movie_detail_<%= movie.id %> movie_detail text-white">
         あらすじを見る<i class="fa fa-chevron-down"></i>
       </button>
     </div>
-    <div class="collapse mt-3" id="movie_detail">
+    <div class="collapse mt-3" id="js-movie_detail_<%= movie.id %>">
       <div class="card card-body text-start">
         <%= movie.overview %>
       </div>


### PR DESCRIPTION
1つのあらすじを開くと、すべてのあらすじが開くようになっていた。
それを、個別のIDを振り分けて、個別のあらすじが開くように修正しました。