### PR TITLE
Feature/#9 view history

### DIFF
--- a/app/controllers/admin/movies_controller.rb
+++ b/app/controllers/admin/movies_controller.rb
@@ -56,7 +56,7 @@ class Admin::MoviesController < ApplicationController
       @movie.api_id = @detail_result['id']
       @movie.title = @detail_result['title']
       @movie.runtime = @detail_result['runtime']
-      @movie.user_score = @detail_result['vote_average'].to_i * 10
+      @movie.user_score = @detail_result['vote_average'] * 10
       @movie.release_date = @detail_result['release_date']
       @movie.overview = @detail_result['overview']
       @movie.poster_url = @detail_result['poster_path']

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -2,6 +2,14 @@ class MoviesController < ApplicationController
   skip_before_action :require_login, only: %i[index]
 
   def index
-    @movies = Movie.all.order(user_score: :desc)
+    if cookies['cinemat']
+      view_history = cookies['cinemat']
+      last_views_movie = Movie.find(view_history.to_i)
+      next_movie = last_views_movie.next
+      all_movies = Movie.all.order(user_score: :desc)
+      @movies = all_movies[all_movies.index(next_movie)..all_movies.index(all_movies.last)]
+    else
+      @movies = Movie.all.order(user_score: :desc)
+    end
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -3,12 +3,14 @@ class MoviesController < ApplicationController
 
   def index
     if cookies['cinemat']
-      view_history = cookies['cinemat']
-      last_views_movie = Movie.find(view_history.to_i)
-      next_movie = last_views_movie.next
+      # ブラウザを閉じる前に観ていた映画を取得
+      last_viewed_movie = Movie.find(cookies['cinemat'].to_i)
+      # 全映画をユーザースコア順に並べて取得
       all_movies = Movie.all.order(user_score: :desc)
-      @movies = all_movies[all_movies.index(next_movie)..all_movies.index(all_movies.last)]
+      # 全映画の中から、ブラウザを閉じる前に観ていた映画の次の映画から、最後のデータまで取得
+      @movies = all_movies[all_movies.index(last_viewed_movie) + 1..all_movies.index(all_movies.last)]
     else
+      # 全映画をユーザースコア順に並べて取得
       @movies = Movie.all.order(user_score: :desc)
     end
   end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -23,8 +23,4 @@ class Movie < ApplicationRecord
   validates :trailer_url, presence: true, uniqueness: true
   validates :poster_url , presence: true, uniqueness: true
   validates :release_date , presence: true, uniqueness: true
-
-  def next
-    Movie.where('user_score < ?', self.user_score).order('user_score DESC').first
-  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -23,4 +23,8 @@ class Movie < ApplicationRecord
   validates :trailer_url, presence: true, uniqueness: true
   validates :poster_url , presence: true, uniqueness: true
   validates :release_date , presence: true, uniqueness: true
+
+  def next
+    Movie.where('user_score < ?', self.user_score).order('user_score DESC').first
+  end
 end

--- a/app/views/admin/movies/search.html.erb
+++ b/app/views/admin/movies/search.html.erb
@@ -58,7 +58,7 @@
           <div class="d-block border-right p-1 m-1 col-3">
             <% if @detail_result['vote_average'].present? %>
               <p class="h5 text-center">user_score</p>
-              <p class="text-center"><%= @detail_result['vote_average'].to_i * 10 %></p>
+              <p class="text-center"><%= @detail_result['vote_average'] * 10 %></p>
             <%end%>
           </div>
           <div class="d-block p-1 m-1 col-3">

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,4 +1,5 @@
-<div class="swiper-slide">
+<div class="swiper-slide js-touch-area-<%=  movie.id %>">
+  <div class="js-movie-id-<%=  movie.id %> d-none"><%=  movie.id %></div>
   <div class="trailer">
     <iframe src="https://www.youtube.com/embed/<%= movie.trailer_url %>" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
@@ -30,3 +31,12 @@
   </div>
   <hr>
 </div>
+
+<script>
+  function pointerMove(){
+    let movieId = document.querySelector('.js-movie-id-<%= movie.id %>').innerHTML;
+    document.cookie = 'cinemat=' + movieId
+  }
+
+  document.querySelector('.js-touch-area-<%=  movie.id %>').addEventListener('pointermove', pointerMove)
+</script>


### PR DESCRIPTION
ブラウザを開き直しても、最後に観た予告の次の予告から、表示されるよう修正しました。

- 予告を観た判定を、jsのイベントハンドラ「pointerMove」で行う
- 予告を観た判定がされたら、予告のIDをクッキーに保存
- クッキーにIDが保存されている場合、トップページで次の予告から表示